### PR TITLE
Add README and sample payment widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# Kaspa dApps
+
+Creating decentralized applications (dApps) with simple copy-and-paste widgets and plug-and-use plugins powered by Smart Contracts on Kaspa.
+
+This repository provides basic examples for quickly adding Kaspa-powered functionality to your project.
+
+## Quick start
+
+1. Choose a widget from the `widgets` directory.
+2. Copy the snippet into your web application.
+3. Configure the options to suit your needs.
+4. Deploy your dApp and go live.
+
+## Widgets
+
+Each widget is a standalone snippet that can be embedded directly into a webpage. The snippets demonstrate how you might interact with Kaspa smart contracts without writing complex code.
+
+See the `widgets` folder for examples.

--- a/widgets/payment-widget.html
+++ b/widgets/payment-widget.html
@@ -1,0 +1,11 @@
+<!-- Example Kaspa Payment Widget -->
+<div id="kaspa-payment-widget">
+  <script src="https://example.com/kaspa-payment.js"></script>
+  <script>
+    // Initialize the payment widget
+    KaspaPayment.init({
+      address: 'kaspa:youraddresshere',
+      amount: 1.0
+    });
+  </script>
+</div>


### PR DESCRIPTION
## Summary
- add short README explaining how to use simple widgets to build Kaspa dApps
- include a sample payment widget snippet

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_683f5086ac9c83328d9e57a59ee2a58d